### PR TITLE
ファイル取得順バグ

### DIFF
--- a/libs/utils/model.py
+++ b/libs/utils/model.py
@@ -15,6 +15,7 @@ def model_compile(model, loss, optimizer):
 def model_load(model, model_folder, idx):
     model_files = glob.glob(os.path.join(
         model_folder, "weights_" + str(idx) + "_*"))
+    model_files = sorted(model_files)
     model_fpath = model_files[-1]
     model.load_weights(model_fpath)
     return
@@ -23,6 +24,7 @@ def model_load(model, model_folder, idx):
 def model_delete(model, model_folder, idx):
     model_files = glob.glob(os.path.join(
         model_folder, "weights_" + str(idx) + "_*"))
+    model_files = sorted(model_files)
     for model_fpath in model_files[:-1]:
         os.remove(model_fpath)
     return


### PR DESCRIPTION
ファイルを取得順に依存するコードになっているがlinuxだと取得順がランダムになっているためバグになっているので取得後に昇順に並び替える修正